### PR TITLE
Refactor models structure and include simple Midi-to-Json converter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
   alias(libs.plugins.kotlin.jvm)
+  alias(libs.plugins.kotlin.serialization)
   application
   `maven-publish`
 }
@@ -14,6 +15,7 @@ repositories {
 
 dependencies {
   implementation("com.github.LucasAlfare:FLBinary:v1.6")
+  implementation(libs.kotlinx.serialization.json)
   testImplementation(kotlin("test"))
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,10 @@
 [versions]
 kotlin = "2.1.10"
+kotlinx-serialization = "1.8.0"
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+
+[libraries]
+kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization"}

--- a/src/main/kotlin/com/lucasalfare/flmidi/MidiParser.kt
+++ b/src/main/kotlin/com/lucasalfare/flmidi/MidiParser.kt
@@ -1,201 +1,10 @@
-@file:OptIn(ExperimentalUnsignedTypes::class, ExperimentalUnsignedTypes::class)
+@file:OptIn(ExperimentalUnsignedTypes::class)
 
 package com.lucasalfare.flmidi
 
 import com.lucasalfare.flbinary.Reader
 import java.io.File
 import kotlin.math.pow
-
-/**
- * Enumeration representing the high-level MIDI event categories.
- *
- * @property code The byte code associated with this event type.
- */
-enum class EventType(val code: Int) {
-  /**
-   * Meta event indicator (always 0xFF).
-   */
-  Meta(0xFF),
-
-  /**
-   * System Exclusive event start indicator (always 0xF0).
-   */
-  SystemExclusive(0xF0),
-
-  /**
-   * System Exclusive event escape indicator (always 0xF7).
-   */
-  SystemExclusiveEscape(0xF7);
-
-  companion object {
-    /**
-     * Retrieves the corresponding [EventType] for the given code.
-     *
-     * @param code The code to lookup.
-     * @return The matching [EventType] if found, otherwise null.
-     */
-    fun fromCode(code: Int): EventType? = entries.find { it.code == code }
-  }
-}
-
-/**
- * Enumeration representing the types of meta events in a MIDI file.
- *
- * @property code The byte code associated with this meta event type.
- */
-enum class MetaEventType(val code: Int) {
-  SequenceNumber(0x00),
-  TextEvent(0x01),
-  CopyrightNotice(0x02),
-  TrackName(0x03),
-  InstrumentName(0x04),
-  Lyric(0x05),
-  Marker(0x06),
-  CuePoint(0x07),
-  MidiChannelPrefix(0x20),
-  SetTempo(0x51),
-  SmpteOffset(0x54),
-  TimeSignature(0x58),
-  KeySignature(0x59),
-  SequencerSpecific(0x7F),
-  EndOfTrack(0x2F),
-
-  /**
-   * Represents an unknown meta event type.
-   */
-  Unknown(-1);
-
-  companion object {
-    /**
-     * Retrieves the corresponding [MetaEventType] for the given code.
-     *
-     * @param code The code to lookup.
-     * @return The matching [MetaEventType] if found; otherwise, [Unknown].
-     */
-    fun fromCode(code: Int): MetaEventType = entries.find { it.code == code } ?: Unknown
-  }
-}
-
-/**
- * Enumeration representing the types of MIDI control (channel) events.
- *
- * @property code The 4-bit code associated with this control event type.
- */
-enum class ControlEventType(val code: Int) {
-  NoteOff(0b1000),
-  NoteOn(0b1001),
-  PolyphonicKeyPressure(0b1010),
-  ControlChange(0b1011),
-  ProgramChange(0b1100),
-  ChannelPressure(0b1101),
-  PitchBend(0b1110);
-
-  companion object {
-    /**
-     * Retrieves the corresponding [ControlEventType] for the given 4-bit code.
-     *
-     * @param code The 4-bit code to lookup.
-     * @return The matching [ControlEventType].
-     * @throws IllegalArgumentException If the code does not correspond to a known control event.
-     */
-    fun fromCode(code: Int): ControlEventType =
-      entries.find { it.code == code } ?: throw IllegalArgumentException(
-        "Unknown control event type: ${code.toString(16)}"
-      )
-  }
-}
-
-/**
- * Base class for all MIDI events.
- */
-open class Event
-
-/**
- * Data class representing a meta event in a MIDI file.
- *
- * @property type The type of meta event (e.g., [MetaEventType.TextEvent], [MetaEventType.SetTempo]).
- * @property deltaTime The delta time before this event occurs.
- * @property data The data payload for this event; its type depends on the event.
- */
-data class MetaEvent(
-  val type: MetaEventType,
-  val deltaTime: Int,
-  val data: Any
-) : Event()
-
-/**
- * Data class representing a control (channel) event in a MIDI file.
- *
- * @property type The type of control event (e.g., [ControlEventType.NoteOn], [ControlEventType.ControlChange]).
- * @property delta The delta time before this event occurs.
- * @property data The data payload for this event.
- * @property targetChannel The MIDI channel associated with this event.
- */
-data class ControlEvent(
-  val type: ControlEventType,
-  val delta: Int,
-  val data: Any,
-  val targetChannel: Int
-) : Event()
-
-/**
- * Data class representing the header chunk of a MIDI file.
- *
- * @property chunkType The signature of the header chunk (must be "MThd").
- * @property length The length of the header chunk in bytes.
- * @property format The format type of the MIDI file (0, 1, or 2).
- * @property numTracks The number of track chunks in the MIDI file.
- * @property division The time division (ticks per quarter note or SMPTE format).
- *
- * The initializer validates that the header signature is correct and that the number
- * of tracks is appropriate for the given format.
- */
-data class Header(
-  val chunkType: String,
-  val length: Long,
-  val format: Int,
-  val numTracks: Int,
-  val division: Int
-) {
-  init {
-    require(chunkType == "MThd") { "Header chunk type signature is not 'MThd'!" }
-    if (format == 0) require(numTracks == 1) { "Format 0 MIDI files must contain exactly one track!" }
-    else if (format == 1 || format == 2) require(numTracks >= 1) { "MIDI file must contain at least one track!" }
-  }
-}
-
-/**
- * Data class representing a track chunk in a MIDI file.
- *
- * @property type The signature of the track chunk (must be "MTrk").
- * @property length The length of the track chunk in bytes.
- * @property events The list of MIDI events contained in the track.
- *
- * The initializer validates that the track signature is correct, the length is positive,
- * and that there is at least one event.
- */
-data class Track(
-  val type: String,
-  val length: Int,
-  val events: List<Event>
-) {
-  init {
-    require(type == "MTrk") { "Track type signature is not 'MTrk'!" }
-    require(length > 0) { "Track with length 0!" }
-    require(events.isNotEmpty()) { "Track without any events!" }
-  }
-}
-
-/**
- * Data class representing an entire MIDI file.
- *
- * @property header The header chunk of the MIDI file.
- * @property tracks The list of track chunks in the MIDI file.
- */
-data class Midi(
-  val header: Header,
-  val tracks: List<Track>
-)
 
 /**
  * Reads a meta event from the provided [reader] using the given [deltaTime].
@@ -215,7 +24,7 @@ private fun readMetaEvent(reader: Reader, deltaTime: Int): MetaEvent {
     MetaEventType.SequenceNumber -> {
       reader.readVariableLengthValue() // data length (usually fixed)
       val sequenceNumber = reader.read2Bytes()
-      MetaEvent(metaType, deltaTime, sequenceNumber)
+      MetaEvent(metaType, deltaTime, NumberEventData(sequenceNumber))
     }
 
     MetaEventType.TextEvent,
@@ -227,7 +36,7 @@ private fun readMetaEvent(reader: Reader, deltaTime: Int): MetaEvent {
     MetaEventType.CuePoint -> {
       val textLength = reader.readVariableLengthValue()
       val data = reader.readString(textLength) ?: ""
-      MetaEvent(metaType, deltaTime, data)
+      MetaEvent(metaType, deltaTime, TextEventData(data))
     }
 
     MetaEventType.TimeSignature -> {
@@ -242,13 +51,13 @@ private fun readMetaEvent(reader: Reader, deltaTime: Int): MetaEvent {
         nMidiClocksInMetronomeClick,
         numberOf32ndNotesIn24MidiClocks
       )
-      MetaEvent(metaType, deltaTime, data)
+      MetaEvent(metaType, deltaTime, NumberListEventData(data))
     }
 
     MetaEventType.SetTempo -> {
       reader.readVariableLengthValue() // number of data items (should be 3)
       val tempoInMicroseconds = reader.read3Bytes()
-      MetaEvent(metaType, deltaTime, tempoInMicroseconds)
+      MetaEvent(metaType, deltaTime, NumberEventData(tempoInMicroseconds))
     }
 
     MetaEventType.SmpteOffset -> {
@@ -260,39 +69,39 @@ private fun readMetaEvent(reader: Reader, deltaTime: Int): MetaEvent {
         reader.read1Byte(),
         reader.read1Byte()
       )
-      MetaEvent(metaType, deltaTime, data)
+      MetaEvent(metaType, deltaTime, NumberListEventData(data))
     }
 
     MetaEventType.KeySignature -> {
       reader.readVariableLengthValue() // data length (should be 2)
       val data = listOf(reader.read1Byte(), reader.read1Byte())
-      MetaEvent(metaType, deltaTime, data)
+      MetaEvent(metaType, deltaTime, NumberListEventData(data))
     }
 
     MetaEventType.MidiChannelPrefix -> {
       reader.readVariableLengthValue() // data length (should be 1)
       val currentEffectiveMidiChannel = reader.read1Byte()
-      MetaEvent(metaType, deltaTime, currentEffectiveMidiChannel)
+      MetaEvent(metaType, deltaTime, NumberEventData(currentEffectiveMidiChannel))
     }
 
     MetaEventType.SequencerSpecific -> {
       val dataLength = reader.readVariableLengthValue()
       val auxBytes = mutableListOf<Int>()
       repeat(dataLength) { auxBytes += reader.read1Byte() }
-      MetaEvent(metaType, deltaTime, auxBytes)
+      MetaEvent(metaType, deltaTime, NumberListEventData(auxBytes))
     }
 
     MetaEventType.EndOfTrack -> {
       val dataLength = reader.readVariableLengthValue()
       require(dataLength == 0) { "End of Track meta event should have zero data length." }
-      MetaEvent(metaType, deltaTime, emptyList<Int>())
+      MetaEvent(metaType, deltaTime, NumberListEventData(emptyList<Int>()))
     }
 
     MetaEventType.Unknown -> {
       println("Unknown meta event encountered: [0x${code.toString(16)}]. Reading anyway...")
       val dataLength = reader.readVariableLengthValue()
       repeat(dataLength) { reader.read1Byte() }
-      MetaEvent(metaType, deltaTime, emptyList<Int>())
+      MetaEvent(metaType, deltaTime, NumberListEventData(emptyList<Int>()))
     }
   }
 }
@@ -317,40 +126,40 @@ private fun readControlEvent(reader: Reader, deltaTime: Int, status: Int): Contr
   return when (val controlType = ControlEventType.fromCode(controlCode)) {
     ControlEventType.ProgramChange -> {
       val targetInstrument = reader.read1Byte()
-      ControlEvent(controlType, deltaTime, targetInstrument, channel)
+      ControlEvent(controlType, deltaTime, NumberEventData(targetInstrument), channel)
     }
 
     ControlEventType.NoteOn, ControlEventType.NoteOff -> {
       val noteNumber = reader.read1Byte() and 0b01111111
       val noteVelocity = reader.read1Byte() and 0b01111111
       val data = listOf(noteNumber, noteVelocity)
-      ControlEvent(controlType, deltaTime, data, channel)
+      ControlEvent(controlType, deltaTime, NumberListEventData(data), channel)
     }
 
     ControlEventType.PolyphonicKeyPressure -> {
       val noteNumber = reader.read1Byte()
       val pressure = reader.read1Byte()
       val data = listOf(noteNumber, pressure)
-      ControlEvent(controlType, deltaTime, data, channel)
+      ControlEvent(controlType, deltaTime, NumberListEventData(data), channel)
     }
 
     ControlEventType.ControlChange -> {
       val controlNumber = reader.read1Byte()
       val controlValue = reader.read1Byte()
       val data = listOf(controlNumber, controlValue)
-      ControlEvent(controlType, deltaTime, data, channel)
+      ControlEvent(controlType, deltaTime, NumberListEventData(data), channel)
     }
 
     ControlEventType.ChannelPressure -> {
       val channelPressure = reader.read1Byte()
-      ControlEvent(controlType, deltaTime, channelPressure, channel)
+      ControlEvent(controlType, deltaTime, NumberEventData(channelPressure), channel)
     }
 
     ControlEventType.PitchBend -> {
       val lsb = reader.read1Byte()
       val msb = reader.read1Byte()
       val pitchBend = (msb shl 7) or lsb
-      ControlEvent(controlType, deltaTime, pitchBend, channel)
+      ControlEvent(controlType, deltaTime, NumberEventData(pitchBend), channel)
     }
   }
 }
@@ -405,7 +214,7 @@ fun readMidi(pathname: String): Midi {
         EventType.Meta.code -> {
           val metaEvent = readMetaEvent(reader, currentDeltaTime)
           events += metaEvent
-          if (metaEvent.type == MetaEventType.EndOfTrack) break
+          if (metaEvent.eventType == MetaEventType.EndOfTrack) break
           previousStatus = 0 // Reset running status after a meta event.
         }
 

--- a/src/main/kotlin/com/lucasalfare/flmidi/Models.kt
+++ b/src/main/kotlin/com/lucasalfare/flmidi/Models.kt
@@ -1,0 +1,225 @@
+package com.lucasalfare.flmidi
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Enumeration representing the high-level MIDI event categories.
+ *
+ * @property code The byte code associated with this event type.
+ */
+@Serializable
+enum class EventType(val code: Int) {
+  /**
+   * Meta event indicator (always 0xFF).
+   */
+  Meta(0xFF),
+
+  /**
+   * System Exclusive event start indicator (always 0xF0).
+   */
+  SystemExclusive(0xF0),
+
+  /**
+   * System Exclusive event escape indicator (always 0xF7).
+   */
+  SystemExclusiveEscape(0xF7);
+
+  companion object {
+    /**
+     * Retrieves the corresponding [EventType] for the given code.
+     *
+     * @param code The code to lookup.
+     * @return The matching [EventType] if found, otherwise null.
+     */
+    fun fromCode(code: Int): EventType? = entries.find { it.code == code }
+  }
+}
+
+/**
+ * Enumeration representing the types of meta events in a MIDI file.
+ *
+ * @property code The byte code associated with this meta event type.
+ */
+@Serializable
+enum class MetaEventType(val code: Int) {
+  SequenceNumber(0x00),
+  TextEvent(0x01),
+  CopyrightNotice(0x02),
+  TrackName(0x03),
+  InstrumentName(0x04),
+  Lyric(0x05),
+  Marker(0x06),
+  CuePoint(0x07),
+  MidiChannelPrefix(0x20),
+  SetTempo(0x51),
+  SmpteOffset(0x54),
+  TimeSignature(0x58),
+  KeySignature(0x59),
+  SequencerSpecific(0x7F),
+  EndOfTrack(0x2F),
+
+  /**
+   * Represents an unknown meta event type.
+   */
+  Unknown(-1);
+
+  companion object {
+    /**
+     * Retrieves the corresponding [MetaEventType] for the given code.
+     *
+     * @param code The code to lookup.
+     * @return The matching [MetaEventType] if found; otherwise, [Unknown].
+     */
+    fun fromCode(code: Int): MetaEventType = entries.find { it.code == code } ?: Unknown
+  }
+
+  override fun toString() = "${this}(0x${code.toString(16).padStart(2, '0')})"
+}
+
+/**
+ * Enumeration representing the types of MIDI control (channel) events.
+ *
+ * @property code The 4-bit code associated with this control event type.
+ */
+@Serializable
+enum class ControlEventType(val code: Int) {
+  NoteOff(0b1000),
+  NoteOn(0b1001),
+  PolyphonicKeyPressure(0b1010),
+  ControlChange(0b1011),
+  ProgramChange(0b1100),
+  ChannelPressure(0b1101),
+  PitchBend(0b1110);
+
+  companion object {
+    /**
+     * Retrieves the corresponding [ControlEventType] for the given 4-bit code.
+     *
+     * @param code The 4-bit code to lookup.
+     * @return The matching [ControlEventType].
+     * @throws IllegalArgumentException If the code does not correspond to a known control event.
+     */
+    fun fromCode(code: Int): ControlEventType =
+      entries.find { it.code == code } ?: throw IllegalArgumentException(
+        "Unknown control event type: ${code.toString(16)}"
+      )
+  }
+
+  override fun toString() = "${this}(0x${code.toString(16).padStart(2, '0')})"
+}
+
+@Serializable
+sealed class EventData
+
+@Serializable
+data class NumberEventData(
+  val number: Int
+) : EventData()
+
+@Serializable
+data class TextEventData(
+  val text: String
+) : EventData()
+
+@Serializable
+data class NumberListEventData(
+  val list: List<Int>
+) : EventData()
+
+/**
+ * Base class for all MIDI events.
+ */
+@Serializable
+sealed class Event
+
+/**
+ * Data class representing a meta event in a MIDI file.
+ *
+ * @property eventType The type of meta event (e.g., [MetaEventType.TextEvent], [MetaEventType.SetTempo]).
+ * @property deltaTime The delta time before this event occurs.
+ * @property data The data payload for this event; its type depends on the event.
+ */
+@Serializable
+data class MetaEvent(
+  val eventType: MetaEventType,
+  val deltaTime: Int,
+  val data: EventData
+) : Event()
+
+/**
+ * Data class representing a control (channel) event in a MIDI file.
+ *
+ * @property eventType The type of control event (e.g., [ControlEventType.NoteOn], [ControlEventType.ControlChange]).
+ * @property delta The delta time before this event occurs.
+ * @property data The data payload for this event.
+ * @property targetChannel The MIDI channel associated with this event.
+ */
+@Serializable
+data class ControlEvent(
+  val eventType: ControlEventType,
+  val delta: Int,
+  val data: EventData,
+  val targetChannel: Int
+) : Event()
+
+/**
+ * Data class representing the header chunk of a MIDI file.
+ *
+ * @property chunkType The signature of the header chunk (must be "MThd").
+ * @property length The length of the header chunk in bytes.
+ * @property format The format type of the MIDI file (0, 1, or 2).
+ * @property numTracks The number of track chunks in the MIDI file.
+ * @property division The time division (ticks per quarter note or SMPTE format).
+ *
+ * The initializer validates that the header signature is correct and that the number
+ * of tracks is appropriate for the given format.
+ */
+@Serializable
+data class Header(
+  val chunkType: String,
+  val length: Long,
+  val format: Int,
+  val numTracks: Int,
+  val division: Int
+) {
+  init {
+    require(chunkType == "MThd") { "Header chunk type signature is not 'MThd'!" }
+    if (format == 0) require(numTracks == 1) { "Format 0 MIDI files must contain exactly one track!" }
+    else if (format == 1 || format == 2) require(numTracks >= 1) { "MIDI file must contain at least one track!" }
+  }
+}
+
+/**
+ * Data class representing a track chunk in a MIDI file.
+ *
+ * @property type The signature of the track chunk (must be "MTrk").
+ * @property length The length of the track chunk in bytes.
+ * @property events The list of MIDI events contained in the track.
+ *
+ * The initializer validates that the track signature is correct, the length is positive,
+ * and that there is at least one event.
+ */
+@Serializable
+data class Track(
+  val type: String,
+  val length: Int,
+  val events: List<Event>
+) {
+  init {
+    require(type == "MTrk") { "Track type signature is not 'MTrk'!" }
+    require(length > 0) { "Track with length 0!" }
+    require(events.isNotEmpty()) { "Track without any events!" }
+  }
+}
+
+/**
+ * Data class representing an entire MIDI file.
+ *
+ * @property header The header chunk of the MIDI file.
+ * @property tracks The list of track chunks in the MIDI file.
+ */
+@Serializable
+data class Midi(
+  val header: Header,
+  val tracks: List<Track>
+)

--- a/src/main/kotlin/com/lucasalfare/flmidi/SimpleMidiJsonParser.kt
+++ b/src/main/kotlin/com/lucasalfare/flmidi/SimpleMidiJsonParser.kt
@@ -1,0 +1,18 @@
+package com.lucasalfare.flmidi
+
+import kotlinx.serialization.json.Json
+
+object SimpleMidiJsonParser {
+
+  private var json = Json { prettyPrint = false }
+  private var prettyPrintJson = Json { prettyPrint = true }
+
+  fun getJsonStringFromMidi(midi: Midi, formatted: Boolean = false): String {
+    if (formatted) return prettyPrintJson.encodeToString(midi)
+    return json.encodeToString(midi)
+  }
+
+  fun getMidiFromJsonString(jsonString: String): Midi {
+    return json.decodeFromString<Midi>(jsonString)
+  }
+}


### PR DESCRIPTION
Now the project treat the data of the events as abstract types, in order to avoid the type `Any`.

Also, I've included a very simple basic `Midi-to-Json` in the project (and the `Json-to-Midi` as well). Should be
helpful.

Unfortunately, due to the event data types abstraction, we need to keep track the full qualifier of the subtypes in the generated json. This is needed in order to make the same code make a possible `Json-to-Midi`, and for this, the `kotlinx.serialization` needs to know what exactly subtype should be used in the process.

In the future, I should to refactor the main data structure of my project to avoid this.